### PR TITLE
Move Claude Code runtime files to ~/.claude/jerbs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ jerbs/
 
 **Runtime files** (created by Claude, not in the repo):
 ```
-~/job-screener-criteria.json     ← your personal screening criteria profile
-~/jerbs-correspondence.json      ← log of all sent replies and recruiter responses
+~/.claude/jerbs/criteria.json        ← your personal screening criteria profile
+~/.claude/jerbs/correspondence.json  ← log of all sent replies and recruiter responses
 ```
 
 ---
@@ -50,7 +50,7 @@ jerbs/
 4. Connect Gmail: **Settings → Connectors → Gmail**
 5. Open a conversation inside the project and say `"run jerbs"`
 
-On first run, Claude walks you through a setup wizard and outputs a `job-screener-criteria.json`
+On first run, Claude walks you through a setup wizard and outputs a `criteria.json`
 file for you to upload to the project. After that, it's loaded automatically in every conversation.
 
 ### Option B — Claude Code (recommended for power users)
@@ -67,7 +67,7 @@ file for you to upload to the project. After that, it's loaded automatically in 
 jerbs adapts automatically to where it's running:
 
 ### Claude Code
-Claude reads and writes `~/job-screener-criteria.json` and `~/jerbs-correspondence.json`
+Claude reads and writes `~/.claude/jerbs/criteria.json` and `~/.claude/jerbs/correspondence.json`
 directly. Nothing extra needed — files stay in sync automatically after every run.
 
 ### Web / Claude Project
@@ -84,7 +84,7 @@ criteria updates).
 
 ## Criteria profile
 
-Your criteria are stored in `job-screener-criteria.json`. Claude creates and updates this
+Your criteria are stored in `criteria.json`. Claude creates and updates this
 file automatically. The full schema is in `criteria_template.json`.
 
 Key sections:
@@ -139,7 +139,7 @@ can never be ambiguous.
 
 ## Correspondence tracking
 
-All sent replies (and dry-run drafts) are logged to `~/jerbs-correspondence.json`. Each
+All sent replies (and dry-run drafts) are logged to `~/.claude/jerbs/correspondence.json`. Each
 entry records the company, role, recipient, full message body, Gmail thread IDs, and
 whether you're still waiting on a reply.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -35,8 +35,8 @@ the start of every session and adapt accordingly. Never ask the user which mode 
 ### Claude Code (filesystem access available)
 **Signal:** bash / file tools are available in the environment.
 
-- Read criteria and correspondence log directly from disk (`~/job-screener-criteria.json`,
-  `~/jerbs-correspondence.json`)
+- Read criteria and correspondence log directly from disk (`~/.claude/jerbs/criteria.json`,
+  `~/.claude/jerbs/correspondence.json`)
 - Write updates directly back to disk after every run — no user action needed
 - This is the zero-friction path
 
@@ -67,9 +67,9 @@ the start of every session and adapt accordingly. Never ask the user which mode 
 
 ## How criteria are stored
 
-Criteria are stored in a JSON profile. The filename is `job-screener-criteria.json`.
+Criteria are stored in a JSON profile. The filename is `criteria.json`.
 
-- **Claude Code:** lives at `~/job-screener-criteria.json`, read/written directly
+- **Claude Code:** lives at `~/.claude/jerbs/criteria.json`, read/written directly
 - **Web/Project:** lives as a project file, read from context, re-uploaded by user after changes
 
 On first run (no criteria found), Claude creates it interactively via the setup wizard.
@@ -82,9 +82,9 @@ The bundled `criteria_template.json` shows the full schema with all fields and d
 ## How correspondence is tracked
 
 All sent replies (and dry-run drafts) are logged to a JSON file named
-`jerbs-correspondence.json`.
+`correspondence.json`.
 
-- **Claude Code:** lives at `~/jerbs-correspondence.json`, read/written directly
+- **Claude Code:** lives at `~/.claude/jerbs/correspondence.json`, read/written directly
 - **Web/Project:** lives as a project file, read from context, re-uploaded by user after changes
 
 Each entry records:
@@ -115,13 +115,25 @@ detected in a subsequent run.
 
 ## Step 0 — Load or set up criteria + correspondence log
 
-**At the start of every interaction**, check whether a criteria file exists:
+**At the start of every interaction** (Claude Code only), check for files at the default
+locations (`~/.claude/jerbs/criteria.json`, `~/.claude/jerbs/correspondence.json`):
 
 ```
-Does the user have a criteria file?
-→ Yes: Load it, load the correspondence log (if it exists), print a brief summary,
-       ask if they want to adjust anything before running.
-→ No: Run the setup wizard (below).
+Do files exist at the default locations?
+→ Yes: Load them. Skip location questions. Go to the summary step below.
+→ No: Ask the user:
+      "Do you already have a criteria file somewhere? If so, where is it?"
+      and
+      "Do you already have a correspondence log somewhere? If so, where is it?"
+
+      For each file the user provides a path for:
+        - Copy it to the default location (~/.claude/jerbs/)
+        - Inform the user: "I've copied your file to ~/.claude/jerbs/. That's the working
+          copy going forward — all updates will be written there, not to the original path."
+
+      For each file the user does not have:
+        - criteria.json missing → run the setup wizard (Step 1)
+        - correspondence.json missing → create an empty log ([] array) at the default path
 ```
 
 **Print send mode status prominently** whenever the criteria are loaded — this must never
@@ -569,7 +581,7 @@ Key fields:
   "interview_process": { "no_unpaid_takehome", "max_rounds" },
   "reply_settings": { "tone", "signature" },
   "send_mode": { "enabled": false, "enabled_at": "" },
-  "correspondence_log_path": "~/jerbs-correspondence.json",
+  "correspondence_log_path": "~/.claude/jerbs/correspondence.json",
   "search_settings": { "lookback_days", "max_results_per_pass", "extra_keywords" },
   "screened_message_ids": []
 }

--- a/criteria_template.json
+++ b/criteria_template.json
@@ -67,7 +67,7 @@
     "enabled_at": "",
     "_note": "When false (dry-run), replies are shown as copy-paste text only. When true, Claude sends replies via Gmail and logs them to the correspondence log. Toggle with 'enable send mode' / 'disable send mode'. Claude always confirms before enabling."
   },
-  "correspondence_log_path": "~/jerbs-correspondence.json",
+  "correspondence_log_path": "~/.claude/jerbs/correspondence.json",
   "search_settings": {
     "lookback_days": "auto",
     "max_results_per_pass": "auto",


### PR DESCRIPTION
## Summary

- Relocated runtime file paths for Claude Code (local) instances from `~/` to `~/.claude/jerbs/`
- Updated first-run setup flow to handle users who may have existing files at non-standard locations
- Web/project runs are unaffected — they continue to use project files as before

## Changes

| File | What changed |
|---|---|
| `SKILL.md` | Updated Claude Code file paths; improved Step 0 to ask for existing file locations on first run, copy them to `~/.claude/jerbs/`, and inform the user that the working copy is now there |
| `criteria_template.json` | Updated `correspondence_log_path` default to `~/.claude/jerbs/correspondence.json` |
| `README.md` | Updated all runtime file path references |

## Why

`~/.claude/` is the natural home for Claude Code data. Keeping jerbs runtime files there avoids polluting `~/` and groups them with other Claude-managed files.

## First-run behavior (new)

If files aren't found at `~/.claude/jerbs/` on startup, Claude now:
1. Asks whether the user has existing files elsewhere
2. Copies them to `~/.claude/jerbs/` if found
3. Tells the user the working copy location has changed — original file is not modified
4. Runs the setup wizard for any missing files

## Test plan

- [ ] Fresh run (no files anywhere) → setup wizard runs
- [ ] Files exist at `~/.claude/jerbs/` → loads silently, no location questions asked
- [ ] Files exist at a custom path → copies to `~/.claude/jerbs/`, informs user of new working location

🤖 Generated with [Claude Code](https://claude.com/claude-code)