### PR TITLE
Add GitHub Actions CI/CD workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: tests/unit/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r tests/unit/requirements.txt
+
+      - name: Run unit tests
+        run: python -m pytest tests/unit/ -v --tb=short

--- a/.github/workflows/redteam.yml
+++ b/.github/workflows/redteam.yml
@@ -1,0 +1,62 @@
+name: Red team
+
+on:
+  workflow_dispatch:
+    inputs:
+      num_tests:
+        description: "Number of auto-generated attack tests per plugin"
+        required: false
+        default: "30"
+
+jobs:
+  redteam:
+    name: Prompt injection red team
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: tests/redteam/requirements.txt
+
+      - name: Install Python dependencies
+        run: pip install -r tests/redteam/requirements.txt
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Copy SKILL.md into redteam harness
+        run: cp SKILL.md tests/redteam/SKILL.md
+
+      - name: Start harness server
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          python tests/redteam/server.py &
+          # Wait for server to be ready
+          for i in $(seq 1 15); do
+            curl -sf http://localhost:8675/health && break
+            sleep 1
+          done
+
+      - name: Run promptfoo red team
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          npx --yes promptfoo@latest redteam run \
+            --config tests/redteam/promptfooconfig.yaml \
+            --no-cache
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: redteam-results
+          path: .promptfoo/
+          retention-days: 30


### PR DESCRIPTION
## Summary

- `ci.yml` — runs unit tests on every PR and push to `main`
- `redteam.yml` — manual-trigger prompt injection red team

## Workflows

### `ci.yml`
- Triggers: `push` to `main`, `pull_request` to `main`
- Python 3.11, pip caching against `tests/unit/requirements.txt`
- Runs `pytest tests/unit/ -v --tb=short`
- Should be set as a required status check on `main` (see setup notes below)

### `redteam.yml`
- Trigger: `workflow_dispatch` only (manual button in GitHub Actions UI)
- Optional input: `num_tests` (default 30) for auto-generated attack count
- Starts the FastAPI harness server, waits for it to be healthy, then runs `promptfoo redteam`
- Uploads `.promptfoo/` results as a workflow artifact (retained 30 days)
- Requires `ANTHROPIC_API_KEY` secret to be set in repo settings

## Setup steps after merge

1. **Add the API key secret:**
   Settings → Secrets and variables → Actions → New repository secret
   Name: `ANTHROPIC_API_KEY`

2. **Enable branch protection on `main`:**
   Settings → Branches → Add rule → Branch name: `main`
   - Check "Require status checks to pass before merging"
   - Search for and add: `Unit tests` (the job name from `ci.yml`)
   - Check "Require branches to be up to date before merging"

3. **Run the red team manually:**
   Actions tab → "Red team" → "Run workflow"

## Test plan

- [ ] Open a PR against `main` — CI workflow should trigger and pass
- [ ] Merge triggers CI on `main`
- [ ] Red team workflow appears in Actions tab and can be triggered manually
- [ ] Red team results appear as a downloadable artifact after the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)