### PR TITLE
Add CI and red team status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # jerbs 🔍
 
+[![CI](https://github.com/pjunod/jerbs/actions/workflows/ci.yml/badge.svg)](https://github.com/pjunod/jerbs/actions/workflows/ci.yml)
+[![Red team](https://github.com/pjunod/jerbs/actions/workflows/redteam.yml/badge.svg)](https://github.com/pjunod/jerbs/actions/workflows/redteam.yml)
+
 A Claude skill that screens your job-related emails against your personal criteria, drafts
 follow-up replies, and tracks your recruiter correspondence — so you only spend time on
 opportunities worth pursuing.


### PR DESCRIPTION
## Summary

Adds GitHub Actions status badges to the top of the README.

- **CI badge** — links to the unit test workflow, shows pass/fail on every PR and push to main
- **Red team badge** — links to the manual red team workflow, shows status of the last run

Badges will show "no status" until the first workflow run completes after the CI/red team PRs are merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)