### PR TITLE
Rename red team workflow to Prompt injection security

### DIFF
--- a/.github/workflows/redteam.yml
+++ b/.github/workflows/redteam.yml
@@ -1,4 +1,4 @@
-name: Red team
+name: Prompt injection security
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # jerbs 🔍
 
 [![CI](https://github.com/pjunod/jerbs/actions/workflows/ci.yml/badge.svg)](https://github.com/pjunod/jerbs/actions/workflows/ci.yml)
-[![Red team](https://github.com/pjunod/jerbs/actions/workflows/redteam.yml/badge.svg)](https://github.com/pjunod/jerbs/actions/workflows/redteam.yml)
+[![Prompt injection security](https://github.com/pjunod/jerbs/actions/workflows/redteam.yml/badge.svg)](https://github.com/pjunod/jerbs/actions/workflows/redteam.yml)
 
 A Claude skill that screens your job-related emails against your personal criteria, drafts
 follow-up replies, and tracks your recruiter correspondence — so you only spend time on


### PR DESCRIPTION
## Summary

Renames the `redteam.yml` workflow from "Red team" to "Prompt injection security" and updates the README badge label to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)